### PR TITLE
Fixed URL-encoded gzip + base64 detection

### DIFF
--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -715,7 +715,7 @@ public class BurpExtender implements IBurpExtender, IScannerCheck, ITab, ActionL
                         issues.add(new CustomScanIssue(
                             baseRequestResponse.getHttpService(),
                             helpers.analyzeRequest(baseRequestResponse).getUrl(), 
-                            new IHttpRequestResponse[] { callbacks.applyMarkers(baseRequestResponse, null, responseMarkers) }, 
+                            new IHttpRequestResponse[] { callbacks.applyMarkers(baseRequestResponse, responseMarkers, null) },
                             issueName,
                             passiveScanSeverity,
                             passiveScanConfidence,

--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -684,11 +684,18 @@ public class BurpExtender implements IBurpExtender, IScannerCheck, ITab, ActionL
 
                 //Check if base64 decoding is necessary
                 if (magicPosBase64Gzip > -1) {
-                    //Extract out string
-                    String extractedObject = helpers.bytesToString(potentialObject);
+                    //Check is URL decoding is necessary before Base64 decoding
+                    boolean urlEncoded = false;
+                    for (int i = 0; i < potentialObject.length; i++) {
+                        if (potentialObject[i] == (byte)'%') {
+                            urlEncoded = true;
+                            break;
+                        }
+                    }
 
                     //Base64 decode
-                    gzippedObject = helpers.base64Decode(extractedObject);
+                    gzippedObject = helpers.base64Decode(urlEncoded ?
+							helpers.urlDecode(potentialObject) : potentialObject);
 
                     //Prematurely set issue name
                     issueName = passiveScanIssue + " in request (encoded in Base64 & Gzipped)";

--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -691,13 +691,13 @@ public class BurpExtender implements IBurpExtender, IScannerCheck, ITab, ActionL
                     gzippedObject = helpers.base64Decode(extractedObject);
 
                     //Prematurely set issue name
-                    issueName = passiveScanIssue + " (encoded in Base64 & Gzipped)";
+                    issueName = passiveScanIssue + " in request (encoded in Base64 & Gzipped)";
                 
                 } else {
                 	
                     //Extract out gzipped object
                     gzippedObject = potentialObject;
-                    issueName = passiveScanIssue + " (Gzipped)";
+                    issueName = passiveScanIssue + " in request (Gzipped)";
                     
                 }
 

--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -706,7 +706,7 @@ public class BurpExtender implements IBurpExtender, IScannerCheck, ITab, ActionL
                     //Gzip decompress first 2 bytes to check header for asciiHexMagic
                     GZIPInputStream gis = new GZIPInputStream(new ByteArrayInputStream(gzippedObject));
                     byte[] ungzip = new byte[2];
-                    gis.read(ungzip, 0, 2);
+                    gis.read(ungzip);
 
                     //Check if ungzip data is the same as serializeMagic
                     if (Arrays.equals(ungzip, serializeMagic)) {

--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -742,7 +742,7 @@ public class BurpExtender implements IBurpExtender, IScannerCheck, ITab, ActionL
                 issues.add(new CustomScanIssue(
                         baseRequestResponse.getHttpService(),
                         helpers.analyzeRequest(baseRequestResponse).getUrl(), 
-                        new IHttpRequestResponse[] { callbacks.applyMarkers(baseRequestResponse, responseMarkers, new ArrayList<int[]>()) }, 
+                        new IHttpRequestResponse[] { callbacks.applyMarkers(baseRequestResponse, responseMarkers, null) },
                         issueName,
                         passiveScanSeverity,
                         passiveScanConfidence,


### PR DESCRIPTION
Several bugs prevented reporting gzipped + base64 encoded Java serialized objects in HTTP requests.

 - URL decoding was not performed, so if the parameter was encoded that way, base64 decoding stopped earlier than it should've and the GZIP decoder threw an exception with the message _"invalid code -- missing end-of-block"_ (fixed in 10602ce)
 - even though the detection ran on the **request**, the markers were stored in a variable called `responseMarkers`, which probably led to the bug that the order of the last two parameters of `applyMarkers` was swapped, leading to weird behavior, since it would only cause Burp to throw exceptions, if these markers were invalid in the scope of response (e.g. big request / small response, fixed in eb63312)

While I was already there, I also fixed some minor other things such as

 - properly indicating that the issue was found in the request, (0c9212d)
 - using `null` instead of empty lists as response markers, (9163066) and
 - removing unnecessary `bytesToString` calls. (10602ce)

I tested this on my own machine, and it seemed to work. See also the individual commit messages, and if you need any more information and/or patches, feel free to comment here.